### PR TITLE
Auto-load Net::Instagram and Net::Twitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,7 @@ If your code never calls the `followers_count` method on a `Twitter::User`, then
 If it does, then replace your calls to `followers_count` with `follower_count` (singular).
 
 * [ENHANCEMENT] Use the same `follower_count` name both for Twitter and Instagram users
+
+## 0.2.1 - 2014-10-20
+
+* [ENHANCEMENT] Requiring 'net' auto-loads Net::Twitter and Net::Instagram

--- a/lib/net.rb
+++ b/lib/net.rb
@@ -1,4 +1,6 @@
 require "net/version"
+require "net/twitter"
+require "net/instagram"
 
 module Net
 end

--- a/lib/net/version.rb
+++ b/lib/net/version.rb
@@ -1,3 +1,3 @@
 module Net
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,4 +7,5 @@ SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
 ]
 SimpleCov.start
 
+require 'net'
 Dir['./spec/support/**/*.rb'].each {|f| require f}

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,7 +1,5 @@
 require 'webmock/rspec'
 require 'vcr'
-require 'net/twitter'
-require 'net/instagram'
 
 VCR.configure do |c|
   c.configure_rspec_metadata!


### PR DESCRIPTION
- Fixes VCR bugs and allows for apps to use Net::Twitter and Net::Instagram without needing to require 'net/twitter' and 'net/instagram'.
- Fixes names of the cassette files due to one-liners in the rspec syntax. See: https://github.com/vcr/vcr/issues/378.
- Does _NOT_ fix the error returned when trying to use Net::Twitter or Net::Instagram without credentials.
