### PR TITLE
Rename followers_count to follower_count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,12 @@ For more information about changelogs, check
 ## 0.1.1 - 2014-10-16
 
 * [FEATURE] Add `Instagram::User` supporting `find_by` and `find_by!`.
+
+## 0.2.0 - 2014-10-20
+
+**How to upgrade**
+
+If your code never calls the `followers_count` method on a `Twitter::User`, then you are good to go.
+If it does, then replace your calls to `followers_count` with `follower_count` (singular).
+
+* [ENHANCEMENT] Use the same `follower_count` name both for Twitter and Instagram users

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ After [configuring your Twitter app](#configuring-your-twitter-app), you can run
 ```ruby
 user = Net::Twitter::User.find_by screen_name: 'fullscreen'
 user.screen_name #=> "Fullscreen"
-user.followers_count #=> 48_200
+user.follower_count #=> 48_200
 ```
 After [configuring your Instagram app](#configuring-your-instagram-app), you can run commands like:
 
@@ -49,10 +49,10 @@ Use [Net::Twitter::User]() to:
 
 ```ruby
 user = Net::Twitter::User.find_by screen_name: 'fullscreen'
-user.followers_count #=> 48_200
+user.follower_count #=> 48_200
 
 users = Net::Twitter::User.where screen_name: ['fullscreen', 'brohemian6']
-users.map(&:followers_count).sort #=> [12, 48_200]
+users.map(&:follower_count).sort #=> [12, 48_200]
 ```
 
 *The methods above require a configured Twitter app (see below).*

--- a/lib/net/twitter/models/user.rb
+++ b/lib/net/twitter/models/user.rb
@@ -5,10 +5,11 @@ module Net
   module Twitter
     module Models
       class User
-        attr_reader :screen_name, :followers_count
+        attr_reader :screen_name, :follower_count
 
         def initialize(attrs = {})
           attrs.each{|k, v| instance_variable_set("@#{k}", v) unless v.nil?}
+          @follower_count = attrs['followers_count']
         end
 
         # Returns the existing Twitter user matching the provided attributes or

--- a/lib/net/version.rb
+++ b/lib/net/version.rb
@@ -1,3 +1,3 @@
 module Net
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end

--- a/spec/net/twitter/models/user_spec.rb
+++ b/spec/net/twitter/models/user_spec.rb
@@ -14,7 +14,7 @@ describe Net::Twitter::User, :vcr do
 
       it 'returns an object representing that user' do
         expect(user.screen_name).to eq 'Fullscreen'
-        expect(user.followers_count).to be_an Integer
+        expect(user.follower_count).to be_an Integer
       end
     end
 
@@ -37,7 +37,7 @@ describe Net::Twitter::User, :vcr do
 
       it 'returns an object representing that user' do
         expect(user.screen_name).to eq 'Fullscreen'
-        expect(user.followers_count).to be_an Integer
+        expect(user.follower_count).to be_an Integer
       end
     end
 
@@ -59,7 +59,7 @@ describe Net::Twitter::User, :vcr do
 
       it 'returns an array of objects representing those users' do
         expect(users.map &:screen_name).to contain_exactly('Fullscreen', 'brohemian6')
-        expect(users.map &:followers_count).to all(be_an Integer)
+        expect(users.map &:follower_count).to all(be_an Integer)
       end
     end
 


### PR DESCRIPTION
- Renames Twitter::User followers_count attribute to follower_count
